### PR TITLE
Align numbers in reporter

### DIFF
--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -56,7 +56,7 @@ export default class BenchmarkReporter extends BaseReporter {
               lines.push([
                 name,
                 `${chalk.green(formatPeriod(period))} \xb1`,
-                `${chalk.cyan(`${rme.toFixed(2)} %`)}`,
+                chalk.cyan(`${rme.toFixed(2)} %`),
                 `(${size} run${size == 1 ? " " : "s"} sampled)`,
               ]);
             }

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -55,8 +55,9 @@ export default class BenchmarkReporter extends BaseReporter {
               const { period } = times;
               lines.push([
                 name,
-                `${chalk.green(formatPeriod(period))} \xb1 ${chalk.cyan(`${rme.toFixed(2)} %`)}`,
-                `(${size} run${size == 1 ? "" : "s"} sampled)`,
+                `${chalk.green(formatPeriod(period))} \xb1`,
+                `${chalk.cyan(`${rme.toFixed(2)} %`)}`,
+                `(${size} run${size == 1 ? " " : "s"} sampled)`,
               ]);
             }
             const maxWidths: number[] = lines.reduce(
@@ -68,7 +69,10 @@ export default class BenchmarkReporter extends BaseReporter {
               []
             );
             for (let line of lines) {
-              this.log("    " + line.map((v, i) => v.padEnd(maxWidths[i])).join("  "));
+              this.log("    " + line.map((v, i) => {
+                const w = maxWidths[i];
+                return i === 0 ? v.padEnd(w) : v.padStart(w);
+              }).join("  "));
             }
           }
         })


### PR DESCRIPTION
Thanks for making this library! This PR modifies the reporter to always align numbers. Example before:
```
Benchmarks:
  foo
    bar baz  1.23 ms ± 0.00 %     (1 run sampled)
    qux      45.67 ms ± 7.65 %    (34 runs sampled)
    norf     890.12 ms ± 10.98 %  (2 runs sampled)
```
After:
```
Benchmarks:
  foo
    bar baz    1.23 ms ±   0.00 %   (1 run  sampled)
    qux       45.67 ms ±   7.65 %  (34 runs sampled)
    norf     890.12 ms ±  10.98 %   (2 runs sampled)
```