### PR TITLE
Align period across different scales

### DIFF
--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -13,9 +13,9 @@ const formatPeriod = (num: number) => {
   } else if (num < 10 ** -3) {
     return `${(num * 10 ** 3).toFixed(3)} ms`;
   } else if (num < 1) {
-    return `${(num * 10 ** 3).toFixed(2)} ms`;
+    return `${(num * 10 ** 3).toFixed(2)}  ms`;
   }
-  return `${num.toFixed(2)} s`;
+  return `${num.toFixed(2)}   s`;
 };
 
 export default class BenchmarkReporter extends BaseReporter {


### PR DESCRIPTION
Nitpicky followup to #2. Before:
```
Benchmarks:
  foo
    bar  374.98 ms ±  1.30 %  (11 runs sampled)
    baz     1.10 s ±  2.62 %   (7 runs sampled)
    qux   0.123 ms ±  5.30 %  (38 runs sampled)
```
After:
```
Benchmarks:
  foo
    bar  374.98  ms ±  1.30 %  (11 runs sampled)
    baz    1.10   s ±  2.62 %   (7 runs sampled)
    qux    0.123 ms ±  5.30 %  (38 runs sampled)
```