### PR TITLE
fix: create the benchmark folder in the root directory

### DIFF
--- a/src/environment.ts
+++ b/src/environment.ts
@@ -18,6 +18,7 @@ export default class BenchmarkEnvironment {
   moduleMocker: any;
   fakeTimers: any;
   fakeTimersModern: any;
+  protected _rootDir: string;
 
   constructor(config: ConstructorConfig, context?: EnvironmentContext) {
     const { testEnvironment, testEnvironmentOptions } = config.projectConfig.testEnvironmentOptions;
@@ -45,6 +46,7 @@ export default class BenchmarkEnvironment {
     this.fakeTimers = env.fakeTimers || null;
     this.moduleMocker = env.moduleMocker || null;
     this.fakeTimersModern = env.fakeTimersModern || null;
+    this._rootDir = config.globalConfig.rootDir;
     if (env.getVmContext) {
       function getVmContext() {
         return env.getVmContext();
@@ -71,16 +73,16 @@ export default class BenchmarkEnvironment {
   }
 
   get resultFile() {
-    return path.join(process.cwd(), "benchmarks", "result.txt");
+    return path.join(this._rootDir, "benchmarks", "result.txt");
   }
 
   async teardown() {
     const store = getStore(this.global);
-    const folder = path.join(process.cwd(), "benchmarks");
+    const fileName = this.resultFile;
+    const folder = path.dirname(fileName);
     if (!fs.existsSync(folder)) {
       fs.mkdirSync(folder);
     }
-    const fileName = this.resultFile;
     if (!fs.existsSync(fileName)) {
       fs.writeFileSync(fileName, "");
     }

--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -20,10 +20,12 @@ const formatPeriod = (num: number) => {
 
 export default class BenchmarkReporter extends BaseReporter {
   protected _globalConfig: Config.GlobalConfig;
+  protected _rootDir: string;
 
   constructor(globalConfig: Config.GlobalConfig) {
     super();
     this._globalConfig = globalConfig;
+    this._rootDir = globalConfig.rootDir;
   }
 
   onRunStart(results: AggregatedResult, options: ReporterOnStartOptions): void {
@@ -35,7 +37,7 @@ export default class BenchmarkReporter extends BaseReporter {
   }
 
   get resultFile() {
-    return path.join(process.cwd(), "benchmarks", "result.txt");
+    return path.join(this._rootDir, "benchmarks", "result.txt");
   }
 
   onRunComplete(): Promise<void> {


### PR DESCRIPTION
Fix an issue I mentioned in #8 

> One problem with the current implementation is that the file in generated in the [process working directory](https://github.com/pckhoi/jest-bench/blob/main/src/reporter.ts#L38). That does not play well with a monorepo setup.