### PR TITLE
Added nanosecond support

### DIFF
--- a/src/reporter.ts
+++ b/src/reporter.ts
@@ -8,12 +8,14 @@ import chalk from "chalk";
 import ndjson from "ndjson";
 
 const formatPeriod = (num: number) => {
-  if (num < 10 ** -6) {
-    return `${(num * 10 ** 6).toFixed(3)} μs`;
-  } else if (num < 10 ** -3) {
-    return `${(num * 10 ** 3).toFixed(3)} ms`;
+  if (num < 1e-9) {
+    return `${(num * 1e9).toFixed(3)} ns`;
+  } else if (num < 1e-6) {
+    return `${(num * 1e6).toFixed(3)} μs`;
+  } else if (num < 1e-3) {
+    return `${(num * 1e3).toFixed(3)} ms`;
   } else if (num < 1) {
-    return `${(num * 10 ** 3).toFixed(2)} ms`;
+    return `${(num * 1e3).toFixed(2)} ms`;
   }
   return `${num.toFixed(2)} s`;
 };


### PR DESCRIPTION
Added nanosecond support for those super speedy operations

![image](https://github.com/pckhoi/jest-bench/assets/25303451/ff209f99-2c35-4a84-a56d-0981fdb421fd)

Will only show when the time goes sub 0.001 microsecond, following the pattern the other formatters use